### PR TITLE
Localize UI text through string resources

### DIFF
--- a/app/src/main/kotlin/com/example/leveluplccd/CareerScreen.kt
+++ b/app/src/main/kotlin/com/example/leveluplccd/CareerScreen.kt
@@ -9,20 +9,22 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.annotation.StringRes
 
-private data class Career(val title: String, val description: String, val url: String)
+private data class Career(@StringRes val title: Int, @StringRes val description: Int, val url: String)
 
 private val careers = listOf(
     Career(
-        title = "BS Computer Science",
-        description = "Focus on software engineering, algorithms, and AI.",
+        title = R.string.bs_computer_science_title,
+        description = R.string.bs_computer_science_description,
         url = "https://lccd.edu"
     ),
     Career(
-        title = "BS Information Systems",
-        description = "Blend of business processes and IT solutions.",
+        title = R.string.bs_information_systems_title,
+        description = R.string.bs_information_systems_description,
         url = "https://lccd.edu"
     )
 )
@@ -31,7 +33,7 @@ private val careers = listOf(
 @Composable
 fun CareerScreen() {
     val context = LocalContext.current
-    Scaffold(topBar = { SmallTopAppBar(title = { Text("Career Explorer") }) }) { padding ->
+    Scaffold(topBar = { SmallTopAppBar(title = { Text(stringResource(id = R.string.career_explorer)) }) }) { padding ->
         LazyColumn(
             modifier = Modifier
                 .padding(padding)
@@ -43,15 +45,15 @@ fun CareerScreen() {
                     .fillMaxWidth()
                     .padding(vertical = 8.dp)) {
                     Column(modifier = Modifier.padding(16.dp)) {
-                        Text(career.title, style = MaterialTheme.typography.titleMedium)
+                        Text(stringResource(id = career.title), style = MaterialTheme.typography.titleMedium)
                         Spacer(Modifier.height(8.dp))
-                        Text(career.description)
+                        Text(stringResource(id = career.description))
                         Spacer(Modifier.height(8.dp))
                         Button(onClick = {
                             val intent = Intent(Intent.ACTION_VIEW, Uri.parse(career.url))
                             context.startActivity(intent)
                         }) {
-                            Text("Learn More")
+                            Text(stringResource(id = R.string.learn_more))
                         }
                     }
                 }

--- a/app/src/main/kotlin/com/example/leveluplccd/LeaderboardScreen.kt
+++ b/app/src/main/kotlin/com/example/leveluplccd/LeaderboardScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.material3.ExperimentalMaterial3Api
 
@@ -21,7 +22,7 @@ private val players = listOf(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LeaderboardScreen() {
-    Scaffold(topBar = { SmallTopAppBar(title = { Text("Leaderboard") }) }) { padding ->
+    Scaffold(topBar = { SmallTopAppBar(title = { Text(stringResource(id = R.string.leaderboard)) }) }) { padding ->
         LazyColumn(
             modifier = Modifier
                 .padding(padding)
@@ -34,11 +35,11 @@ fun LeaderboardScreen() {
                         .padding(16.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Text(text = "${index + 1}.", modifier = Modifier.width(24.dp))
+                    Text(text = stringResource(id = R.string.rank_format, index + 1), modifier = Modifier.width(24.dp))
                     Column(modifier = Modifier.weight(1f)) {
                         Text(player.name, style = MaterialTheme.typography.titleMedium)
                     }
-                    Text(text = "${player.points} pts")
+                    Text(text = stringResource(id = R.string.points, player.points))
                 }
                 Divider()
             }

--- a/app/src/main/kotlin/com/example/leveluplccd/quest/DailyQuestScreen.kt
+++ b/app/src/main/kotlin/com/example/leveluplccd/quest/DailyQuestScreen.kt
@@ -56,7 +56,7 @@ fun DailyQuestScreen() {
                 }
                 Spacer(modifier = Modifier.height(16.dp))
                 state.feedback?.let {
-                    Text(text = it)
+                    Text(text = stringResource(id = it))
                     state.explanation?.let { exp -> Text(text = exp) }
                     Spacer(modifier = Modifier.height(16.dp))
                     Button(onClick = { viewModel.clearFeedback() }) {

--- a/app/src/main/kotlin/com/example/leveluplccd/quest/DailyQuestViewModel.kt
+++ b/app/src/main/kotlin/com/example/leveluplccd/quest/DailyQuestViewModel.kt
@@ -3,6 +3,8 @@ package com.example.leveluplccd.quest
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import androidx.annotation.StringRes
+import com.example.leveluplccd.R
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -16,7 +18,7 @@ data class DailyQuestState(
     val quest: Quest? = null,
     val score: Int = 0,
     val streak: Int = 0,
-    val feedback: String? = null,
+    @StringRes val feedback: Int? = null,
     val explanation: String? = null
 )
 
@@ -51,7 +53,7 @@ class DailyQuestViewModel(private val repository: QuestRepository) : ViewModel()
             val quest = _state.value.quest
             _state.update {
                 it.copy(
-                    feedback = if (correct) "Correct!" else "Try again",
+                    feedback = if (correct) R.string.correct_feedback else R.string.try_again_feedback,
                     explanation = if (correct) quest?.explanation else null
                 )
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,4 +8,13 @@
     <string name="next_question">Next Question</string>
     <string name="streak">Streak: %1$d</string>
     <string name="score">Score: %1$d</string>
+    <string name="learn_more">Learn More</string>
+    <string name="correct_feedback">Correct!</string>
+    <string name="try_again_feedback">Try again</string>
+    <string name="points">%1$d pts</string>
+    <string name="rank_format">%1$d.</string>
+    <string name="bs_computer_science_title">BS Computer Science</string>
+    <string name="bs_computer_science_description">Focus on software engineering, algorithms, and AI.</string>
+    <string name="bs_information_systems_title">BS Information Systems</string>
+    <string name="bs_information_systems_description">Blend of business processes and IT solutions.</string>
 </resources>


### PR DESCRIPTION
## Summary
- Replace hardcoded labels in Career and Leaderboard screens with string resources
- Add resource IDs for feedback messages in DailyQuestViewModel and show them via stringResource
- Introduce string resources for career details, feedback messages, and leaderboard formatting

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a54406f0d08324b1829d1e68841d31