### PR TITLE
Specify data extraction backup include/exclude rules

### DIFF
--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -5,10 +5,8 @@
 -->
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <include domain="sharedpref" path="."/>
+        <exclude domain="sharedpref" path="device.xml"/>
     </cloud-backup>
     <!--
     <device-transfer>


### PR DESCRIPTION
## Summary
- configure `data_extraction_rules.xml` with shared preference include/exclude entries

## Testing
- ⚠️ `./gradlew test` *(failed: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a545c3a7cc8324bbdbf8741f629b7b