### PR TITLE
refactor: separate data and domain layers

### DIFF
--- a/app/src/main/kotlin/com/example/leveluplccd/MainActivity.kt
+++ b/app/src/main/kotlin/com/example/leveluplccd/MainActivity.kt
@@ -11,9 +11,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.navigation.compose.composable
 import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.example.leveluplccd.ui.quest.DailyQuestScreen
 import com.example.leveluplccd.ui.theme.LevelUpLccdTheme
 
 class MainActivity : ComponentActivity() {
@@ -31,7 +32,7 @@ fun LevelUpLccdApp() {
             composable(Destinations.Home.route) {
                 HomeScreen(onNavigate = { navController.navigate(it.route) })
             }
-            composable(Destinations.Quest.route) { com.example.leveluplccd.quest.DailyQuestScreen() }
+            composable(Destinations.Quest.route) { DailyQuestScreen() }
             composable(Destinations.Career.route) { CareerScreen() }
             composable(Destinations.Leaderboard.route) { LeaderboardScreen() }
         }

--- a/app/src/main/kotlin/com/example/leveluplccd/data/QuestRepository.kt
+++ b/app/src/main/kotlin/com/example/leveluplccd/data/QuestRepository.kt
@@ -1,4 +1,4 @@
-package com.example.leveluplccd.quest
+package com.example.leveluplccd.data
 
 import android.content.Context
 import androidx.datastore.core.DataStore
@@ -6,6 +6,8 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.example.leveluplccd.domain.Quest
+import com.example.leveluplccd.domain.QuestOption
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map

--- a/app/src/main/kotlin/com/example/leveluplccd/domain/DailyQuestViewModel.kt
+++ b/app/src/main/kotlin/com/example/leveluplccd/domain/DailyQuestViewModel.kt
@@ -1,10 +1,11 @@
-package com.example.leveluplccd.quest
+package com.example.leveluplccd.domain
 
+import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import androidx.annotation.StringRes
 import com.example.leveluplccd.R
+import com.example.leveluplccd.data.QuestRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/app/src/main/kotlin/com/example/leveluplccd/domain/Quest.kt
+++ b/app/src/main/kotlin/com/example/leveluplccd/domain/Quest.kt
@@ -1,4 +1,4 @@
-package com.example.leveluplccd.quest
+package com.example.leveluplccd.domain
 
 /** Represents a single answer option for a [Quest]. */
 data class QuestOption(

--- a/app/src/main/kotlin/com/example/leveluplccd/ui/quest/DailyQuestScreen.kt
+++ b/app/src/main/kotlin/com/example/leveluplccd/ui/quest/DailyQuestScreen.kt
@@ -1,4 +1,4 @@
-package com.example.leveluplccd.quest
+package com.example.leveluplccd.ui.quest
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Button
@@ -16,6 +16,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.leveluplccd.R
+import com.example.leveluplccd.data.QuestRepository
+import com.example.leveluplccd.domain.DailyQuestViewModel
+import com.example.leveluplccd.domain.DailyQuestViewModelFactory
 
 /** Composable screen that presents the daily quest. */
 @Composable

--- a/app/src/test/kotlin/com/example/leveluplccd/data/QuestRepositoryTest.kt
+++ b/app/src/test/kotlin/com/example/leveluplccd/data/QuestRepositoryTest.kt
@@ -1,4 +1,4 @@
-package com.example.leveluplccd.quest
+package com.example.leveluplccd.data
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences


### PR DESCRIPTION
## Summary
- introduce `data` and `domain` packages
- move `QuestRepository` to data and quest model/viewmodel to domain
- relocate `DailyQuestScreen` under `ui` and update navigation

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a557bfb85083248ca606a69df72d87