### PR TITLE
Move career and leaderboard screens into UI packages

### DIFF
--- a/app/src/main/kotlin/com/example/leveluplccd/MainActivity.kt
+++ b/app/src/main/kotlin/com/example/leveluplccd/MainActivity.kt
@@ -14,6 +14,8 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.example.leveluplccd.ui.career.CareerScreen
+import com.example.leveluplccd.ui.leaderboard.LeaderboardScreen
 import com.example.leveluplccd.ui.quest.DailyQuestScreen
 import com.example.leveluplccd.ui.theme.LevelUpLccdTheme
 

--- a/app/src/main/kotlin/com/example/leveluplccd/ui/career/CareerScreen.kt
+++ b/app/src/main/kotlin/com/example/leveluplccd/ui/career/CareerScreen.kt
@@ -1,4 +1,4 @@
-package com.example.leveluplccd
+package com.example.leveluplccd.ui.career
 
 import android.content.Intent
 import android.net.Uri
@@ -13,6 +13,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.annotation.StringRes
+import com.example.leveluplccd.R
 
 private data class Career(@StringRes val title: Int, @StringRes val description: Int, val url: String)
 

--- a/app/src/main/kotlin/com/example/leveluplccd/ui/leaderboard/LeaderboardScreen.kt
+++ b/app/src/main/kotlin/com/example/leveluplccd/ui/leaderboard/LeaderboardScreen.kt
@@ -1,4 +1,4 @@
-package com.example.leveluplccd
+package com.example.leveluplccd.ui.leaderboard
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -10,6 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.material3.ExperimentalMaterial3Api
+import com.example.leveluplccd.R
 
 private data class Player(val name: String, val points: Int)
 


### PR DESCRIPTION
## Summary
- move CareerScreen and LeaderboardScreen into ui subpackages
- update MainActivity imports for relocated screens

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a55df237ec8324b622414998c60348