### PR TITLE
chore: update to latest stable android sdk

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,12 +6,12 @@ plugins {
 
 android {
     namespace = "com.example.leveluplccd"
-    compileSdk = 36
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "com.example.leveluplccd"
         minSdk = 28
-        targetSdk = 36
+        targetSdk = 34
         versionCode = 1
         versionName = "1.0"
 


### PR DESCRIPTION
## Summary
- align compile and target SDK to Android 14 (API 34)

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a562fbaa0c8324b5db9f7b7ae89a3c