### PR TITLE
Load env vars into BuildConfig and use Config for URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+.env

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
     alias(libs.plugins.kotlin.compose)
 }
 
+apply(from = rootProject.file("gradle/env.gradle"))
+
 android {
     namespace = "com.example.leveluplccd"
     compileSdk = 34
@@ -36,6 +38,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 
 }

--- a/app/src/main/kotlin/com/example/leveluplccd/ui/career/CareerScreen.kt
+++ b/app/src/main/kotlin/com/example/leveluplccd/ui/career/CareerScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.annotation.StringRes
 import com.example.leveluplccd.R
+import com.example.leveluplccd.util.Config
 
 private data class Career(@StringRes val title: Int, @StringRes val description: Int, val url: String)
 
@@ -21,12 +22,12 @@ private val careers = listOf(
     Career(
         title = R.string.bs_computer_science_title,
         description = R.string.bs_computer_science_description,
-        url = "https://lccd.edu"
+        url = Config.apiBaseUrl
     ),
     Career(
         title = R.string.bs_information_systems_title,
         description = R.string.bs_information_systems_description,
-        url = "https://lccd.edu"
+        url = Config.apiBaseUrl
     )
 )
 

--- a/app/src/main/kotlin/com/example/leveluplccd/util/Config.kt
+++ b/app/src/main/kotlin/com/example/leveluplccd/util/Config.kt
@@ -1,0 +1,17 @@
+package com.example.leveluplccd.util
+
+import com.example.leveluplccd.BuildConfig
+
+/**
+ * Provides access to build-time configuration values from the .env file.
+ */
+object Config {
+    val firebaseApiKey: String = BuildConfig.FIREBASE_API_KEY
+    val firebaseAuthDomain: String = BuildConfig.FIREBASE_AUTH_DOMAIN
+    val firebaseProjectId: String = BuildConfig.FIREBASE_PROJECT_ID
+    val firebaseStorageBucket: String = BuildConfig.FIREBASE_STORAGE_BUCKET
+    val firebaseMessagingSenderId: String = BuildConfig.FIREBASE_MESSAGING_SENDER_ID
+    val firebaseAppId: String = BuildConfig.FIREBASE_APP_ID
+    val firebaseMeasurementId: String = BuildConfig.FIREBASE_MEASUREMENT_ID
+    val apiBaseUrl: String = BuildConfig.API_BASE_URL
+}

--- a/gradle/env.gradle
+++ b/gradle/env.gradle
@@ -1,0 +1,25 @@
+def envFile = rootProject.file('.env')
+def env = new Properties()
+if (envFile.exists()) {
+    envFile.withInputStream { env.load(it) }
+}
+
+def keys = [
+    'FIREBASE_API_KEY',
+    'FIREBASE_AUTH_DOMAIN',
+    'FIREBASE_PROJECT_ID',
+    'FIREBASE_STORAGE_BUCKET',
+    'FIREBASE_MESSAGING_SENDER_ID',
+    'FIREBASE_APP_ID',
+    'FIREBASE_MEASUREMENT_ID',
+    'API_BASE_URL'
+]
+
+android {
+    defaultConfig {
+        keys.each { key ->
+            def value = env.getProperty(key, '')
+            buildConfigField 'String', key, '"' + value + '"'
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Read `.env` variables during build and expose them as BuildConfig fields
- Provide a `Config` object for accessing environment-driven values
- Replace hardcoded career URLs with `Config.apiBaseUrl`
- Ignore local `.env` files

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a56665cf9883249c851e2b7e733cff