### PR TITLE
chore: opt in ExperimentalMaterial3Api

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,6 +35,7 @@ android {
     }
     kotlinOptions {
         jvmTarget = "11"
+        freeCompilerArgs += "-Xopt-in=androidx.compose.material3.ExperimentalMaterial3Api"
     }
     buildFeatures {
         compose = true

--- a/app/src/main/kotlin/com/example/leveluplccd/ui/quest/DailyQuestScreen.kt
+++ b/app/src/main/kotlin/com/example/leveluplccd/ui/quest/DailyQuestScreen.kt
@@ -2,6 +2,7 @@ package com.example.leveluplccd.ui.quest
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SmallTopAppBar
@@ -19,6 +20,7 @@ import com.example.leveluplccd.domain.DailyQuestViewModel
 import com.example.leveluplccd.domain.DailyQuestViewModelFactory
 
 /** Composable screen that presents the daily quest. */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DailyQuestScreen(viewModelFactory: DailyQuestViewModelFactory) {
     val viewModel: DailyQuestViewModel = viewModel(


### PR DESCRIPTION
## Summary
- opt in to ExperimentalMaterial3Api in DailyQuestScreen
- enable module-wide opt-in for ExperimentalMaterial3Api

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a56acacde08324ba7fd5c2bbfaba42