### PR TITLE
Close DataStore in tests to avoid UncompletedCoroutinesError

### DIFF
--- a/app/src/test/kotlin/com/example/leveluplccd/data/QuestRepositoryTest.kt
+++ b/app/src/test/kotlin/com/example/leveluplccd/data/QuestRepositoryTest.kt
@@ -1,6 +1,8 @@
 package com.example.leveluplccd.data
 
+import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.TestScope
@@ -18,36 +20,44 @@ class QuestRepositoryTest {
     @get:Rule
     val tmp = TemporaryFolder()
 
-    private fun TestScope.createRepository(): QuestRepository {
+    private fun TestScope.createRepository(): Pair<QuestRepository, DataStore<Preferences>> {
         val dataStore = PreferenceDataStoreFactory.create(scope = this) {
             tmp.newFile("test.preferences_pb")
         }
-        return QuestRepository(dataStore)
+        return QuestRepository(dataStore) to dataStore
     }
 
     @Test
     fun correctAnswerRotatesQuestAndIncrementsScore() = runTest {
-        val repo = createRepository()
-        val firstQuest = repo.currentQuest.first()
-        val result = repo.submitAnswer(firstQuest.correctOptionId)
-        val secondQuest = repo.currentQuest.first()
-        assertTrue(result)
-        assertTrue(firstQuest.id != secondQuest.id)
-        assertEquals(1, repo.score.first())
-        assertEquals(1, repo.streak.first())
+        val (repo, dataStore) = createRepository()
+        try {
+            val firstQuest = repo.currentQuest.first()
+            val result = repo.submitAnswer(firstQuest.correctOptionId)
+            val secondQuest = repo.currentQuest.first()
+            assertTrue(result)
+            assertTrue(firstQuest.id != secondQuest.id)
+            assertEquals(1, repo.score.first())
+            assertEquals(1, repo.streak.first())
+        } finally {
+            dataStore.close()
+        }
     }
 
     @Test
     fun incorrectAnswerKeepsQuestAndResetsStreak() = runTest {
-        val repo = createRepository()
-        val firstQuest = repo.currentQuest.first()
-        val wrongOption = firstQuest.options.first { it.id != firstQuest.correctOptionId }.id
-        val result = repo.submitAnswer(wrongOption)
-        val questAfter = repo.currentQuest.first()
-        assertFalse(result)
-        assertEquals(firstQuest.id, questAfter.id)
-        assertEquals(0, repo.score.first())
-        assertEquals(0, repo.streak.first())
+        val (repo, dataStore) = createRepository()
+        try {
+            val firstQuest = repo.currentQuest.first()
+            val wrongOption = firstQuest.options.first { it.id != firstQuest.correctOptionId }.id
+            val result = repo.submitAnswer(wrongOption)
+            val questAfter = repo.currentQuest.first()
+            assertFalse(result)
+            assertEquals(firstQuest.id, questAfter.id)
+            assertEquals(0, repo.score.first())
+            assertEquals(0, repo.streak.first())
+        } finally {
+            dataStore.close()
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Ensure QuestRepositoryTest returns DataStore alongside repository and closes it after each test
- Update DailyQuestViewModelTest to close DataStore after tests

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a56e472e908324aa50c2f01a1f69d6