### PR TITLE
Replace deprecated opt-in compiler flag

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,6 +35,7 @@ android {
     }
     kotlinOptions {
         jvmTarget = "11"
+        freeCompilerArgs += "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api"
     }
     buildFeatures {
         compose = true


### PR DESCRIPTION
## Summary
- use updated `-opt-in` flag for `ExperimentalMaterial3Api`

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a5732b95dc8324a161a39a31febf78